### PR TITLE
use SQLITE_TRANSIENT at bind method

### DIFF
--- a/include/WonderRabbitProject/SQLite3.hpp
+++ b/include/WonderRabbitProject/SQLite3.hpp
@@ -112,7 +112,7 @@ namespace WonderRabbitProject
           , index
           , text.data()
           , text.size()
-          , nullptr
+          , ((C::sqlite3_destructor_type)-1)
           )
         );
         validate(r);
@@ -127,7 +127,7 @@ namespace WonderRabbitProject
           , index
           , text.data()
           , text.size()
-          , nullptr
+          , ((C::sqlite3_destructor_type)-1)
           )
         );
         validate(r);


### PR DESCRIPTION
Thank you for good sqlite wrapper :)
I found a bug: When bind string to statement, if its size is long (in my case, max size was 23), it didn't work. May be its memory was released so use SQLITE_TRANSIENT( it is defined as `((C::sqlite3_destructor_type)-1)`).
Please check it!
